### PR TITLE
feat: Staking rewards APIs

### DIFF
--- a/src/api/bigDipperApi.ts
+++ b/src/api/bigDipperApi.ts
@@ -92,15 +92,15 @@ export class BigDipperApi {
 		}`
 
 		const resp = await this.graphql_client.query<ValidatorDetailResponse>(query);
-		const map = new Map();
+		const set = new Set();
 		resp.validator.forEach((obj, i) => {
 			if (!obj.validatorStatuses[0]?.jailed) {
 				obj.delegations.forEach(delegation => {
-					map.set(delegation.delegatorAddress, true)
+					set.add(delegation.delegatorAddress)
 				})
 			}
 		})
 
-		return map.size
+		return set.size
 	}
 }

--- a/src/api/bigDipperApi.ts
+++ b/src/api/bigDipperApi.ts
@@ -103,4 +103,15 @@ export class BigDipperApi {
 
 		return set.size
 	}
+
+	get_total_staked_coins = async (): Promise<string> => {
+		let query = `query StakingInfo{
+			staking_pool {
+				bonded_tokens
+			}
+		}`
+
+		const resp = await this.graphql_client.query<{ staking_pool: [{ "bonded_tokens": string }] }>(query);
+		return resp.staking_pool[0].bonded_tokens;
+	}
 }

--- a/src/handlers/totalDelegators.ts
+++ b/src/handlers/totalDelegators.ts
@@ -1,0 +1,11 @@
+import { Request } from "itty-router";
+import { BigDipperApi } from "../api/bigDipperApi";
+import { GraphQLClient } from "../helpers/graphql";
+
+export async function handler(request: Request): Promise<Response> {
+	let gql_client = new GraphQLClient(GRAPHQL_API);
+	let bd_api = new BigDipperApi(gql_client);
+
+	const delegators = await bd_api.get_total_delegator_count();
+	return new Response(JSON.stringify(delegators));
+}

--- a/src/handlers/totalStakedCoins.ts
+++ b/src/handlers/totalStakedCoins.ts
@@ -1,0 +1,12 @@
+import { Request } from "itty-router";
+import { BigDipperApi } from "../api/bigDipperApi";
+import { ncheq_to_cheq_fixed } from "../helpers/currency";
+import { GraphQLClient } from "../helpers/graphql";
+
+export async function handler(request: Request): Promise<Response> {
+	let gql_client = new GraphQLClient(GRAPHQL_API);
+	let bd_api = new BigDipperApi(gql_client);
+
+	let total_staked_coins = await bd_api.get_total_staked_coins();
+	return new Response(ncheq_to_cheq_fixed(Number(total_staked_coins)));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { handler as liquidBalanceHandler } from "./handlers/liquidBalance";
 import { handler as vestingBalanceHandler } from "./handlers/vestingBalance";
 import { handler as vestedBalanceHandler } from "./handlers/vestedBalance";
 import { handler as delegatorCount } from './handlers/delegatorCount';
+import { handler as totalDelegators } from './handlers/totalDelegators';
 
 addEventListener('fetch', (event: FetchEvent) => {
 	const router = Router<Request, IHTTPMethods>()
@@ -18,12 +19,12 @@ function registerRoutes(router: Router) {
 	router.get('/', totalSupplyHandler);
 	router.get('/supply/total', totalSupplyHandler);
 	router.get('/supply/circulating', circulatingSupplyHandler);
+	router.get('/staking/delegators/total', totalDelegators);
 	router.get('/balances/total/:address', totalBalanceHandler);
 	router.get('/balances/liquid/:address', liquidBalanceHandler);
 	router.get('/balances/vesting/:address', vestingBalanceHandler);
 	router.get('/balances/vested/:address', vestedBalanceHandler);
 	router.get('/staking/delegators/:validator_address', delegatorCount);
-
 
 	// 404 for all other requests
 	router.all('*', () => new Response('Not Found.', { status: 404 }))

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { handler as vestingBalanceHandler } from "./handlers/vestingBalance";
 import { handler as vestedBalanceHandler } from "./handlers/vestedBalance";
 import { handler as delegatorCount } from './handlers/delegatorCount';
 import { handler as totalDelegators } from './handlers/totalDelegators';
+import { handler as totalStakedCoins } from "./handlers/totalStakedCoins";
 
 addEventListener('fetch', (event: FetchEvent) => {
 	const router = Router<Request, IHTTPMethods>()
@@ -25,6 +26,7 @@ function registerRoutes(router: Router) {
 	router.get('/balances/vesting/:address', vestingBalanceHandler);
 	router.get('/balances/vested/:address', vestedBalanceHandler);
 	router.get('/staking/delegators/:validator_address', delegatorCount);
+	router.get('/supply/staked', totalStakedCoins);
 
 	// 404 for all other requests
 	router.all('*', () => new Response('Not Found.', { status: 404 }))

--- a/src/types/node.ts
+++ b/src/types/node.ts
@@ -47,3 +47,12 @@ export interface ValidatorAggregateCountResponse {
 		}
 	]
 }
+
+export interface ValidatorDetailResponse {
+	validator: [
+		{
+			validatorStatuses: [{ jailed: boolean }],
+			delegations: [{ delegatorAddress: string }]
+		}
+	]
+}


### PR DESCRIPTION
This PR combines #9 and #10 together because of a probable race condition in cloudflare deployment action.
We add two new APIs:
- [x] Total staked coins on the network - `/supply/staked`
- [x] Total delegators on the network - `/staking/delegators/total` 